### PR TITLE
Simplify redundant capture group

### DIFF
--- a/lib/regex_lab.rb
+++ b/lib/regex_lab.rb
@@ -17,5 +17,5 @@ def first_word_capitalized_and_ends_with_punctuation?(text)
 end
 
 def valid_phone_number?(phone)
-  phone.match(/([0-9] *?){10}|(\([0-9]{3}\)(([0-9]{3}-[0-9]{4})|[0-9]{7})\b)/) ? true : false
+  phone.match(/([0-9] *){10}|(\([0-9]{3}\)(([0-9]{3}-[0-9]{4})|[0-9]{7})\b)/) ? true : false
 end


### PR DESCRIPTION
Using either *, ?, or *? works in this case so i'd go with * in case there are multiple spaces.
http://rubular.com/r/TWyZoe4p6L